### PR TITLE
Fix ReferenceError docment is not defined

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,71 @@
+// Initialize Sentry
+console.log('Initializing Sentry...');
+if (typeof Sentry === 'undefined') {
+    console.warn('Sentry is not available - using mock implementation');
+} else {
+    Sentry.init({
+        dsn: "https://61edb47cb5f442c4602cbe8ebf03b17f@o4509356547833856.ingest.de.sentry.io/4509359456125008",
+        integrations: [new Sentry.BrowserTracing()],
+        tracesSampleRate: 1.0,
+        environment: "demo",
+        release: "demo-app@1.0.0",
+        debug: true, // Enable debug mode
+        beforeSend(event) {
+            console.log('Sentry beforeSend called with event:', event);
+            // Increment error count in localStorage
+            const currentCount = parseInt(localStorage.getItem('errorCount') || '0');
+            console.log('Current error count:', currentCount);
+            localStorage.setItem('errorCount', currentCount + 1);
+            
+            // Update UI
+            const errorCountElement = document.getElementById('error-count');
+            console.log('Error count element:', errorCountElement);
+            if (errorCountElement) {
+                errorCountElement.textContent = currentCount + 1;
+                console.log('Updated error count to:', currentCount + 1);
+            }
+            
+            return event;
+        }
+    });
+    console.log('Sentry initialized');
+}
+
+// Global error handler
+window.onerror = function(message, source, lineno, colno, error) {
+    console.error('Global error handler caught:', {message, source, lineno, colno, error});
+    return false; // Let the default handler run
+};
+
+// Application initialization
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('Demo application initialized');
+    
+    // Intentional Error #1: Undefined variable
+    // This will cause a ReferenceError when the page loads
+    try {
+        //Typo corrected here
+        const bodyElement = document.querySelector('body');
+        console.log(bodyElement);
+    } catch (e) {
+        Sentry.captureException(e);
+    }
+});
+
+// Global utility functions
+function formatDate(dateString) {
+    // Intentional Error #2: No error handling for invalid dates
+    // This will throw an error if dateString is invalid
+    const date = new Date(dateString);
+    return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+}
+
+function parseUserData(data) {
+    // Intentional Error #3: No null check
+    // This will throw if data is null or undefined
+    return {
+        name: data.name.trim(),
+        email: data.email.toLowerCase(),
+        joined: formatDate(data.joinDate)
+    };
+}

--- a/js/error-triggers.js
+++ b/js/error-triggers.js
@@ -1,0 +1,100 @@
+// Error Triggers - Functions to deliberately cause errors for demo purposes
+
+// Trigger a ReferenceError
+function triggerReferenceError() {
+    try {
+        // Undefined variable
+        console.log(undefinedVariable);
+    } catch (error) {
+        console.error('Reference Error triggered:', error);
+        Sentry.captureException(error);
+    }
+}
+
+// Trigger a TypeError
+function triggerTypeError() {
+    try {
+        // Calling a non-function
+        const obj = {};
+        obj.nonExistentFunction();
+    } catch (error) {
+        console.error('Type Error triggered:', error);
+        Sentry.captureException(error);
+    }
+}
+
+// Trigger a SyntaxError (note: this won't be caught at runtime, but at parse time)
+function triggerSyntaxError() {
+    try {
+        // This is a function that contains an eval with a syntax error
+        eval('if (true) { console.log("Missing closing brace"');
+    } catch (error) {
+        console.error('Syntax Error triggered:', error);
+        Sentry.captureException(error);
+    }
+}
+
+// Trigger a browser-specific error
+function triggerBrowserSpecificError() {
+    try {
+        // This will cause different errors in different browsers
+        // In some browsers, document.body.doScroll is not a function
+        // In others, it's undefined
+        document.body.doScroll('up');
+    } catch (error) {
+        console.error('Browser-specific Error triggered:', error);
+        
+        // Add browser information to the error
+        Sentry.withScope(function(scope) {
+            scope.setTag('browser', navigator.userAgent);
+            scope.setExtra('browserInfo', {
+                userAgent: navigator.userAgent,
+                platform: navigator.platform,
+                vendor: navigator.vendor
+            });
+            Sentry.captureException(error);
+        });
+    }
+}
+
+// Trigger different errors based on browser
+(function() {
+    const ua = navigator.userAgent;
+    
+    // Intentional Error #11: Browser-specific code with errors
+    if (ua.indexOf('Chrome') !== -1) {
+        // Chrome-specific error
+        // Intentional Error: Incorrect property name
+        window.addEventListener('load', function() {
+            try {
+                // Chrome-specific API with error
+                const chromeFeature = window.chrome.loadTimes;
+                // This will cause an error in some Chrome versions
+                console.log(chromeFeature.firstPaintTime);
+            } catch (e) {
+                Sentry.captureException(e);
+            }
+        });
+    } else if (ua.indexOf('Firefox') !== -1) {
+        // Firefox-specific error
+        window.addEventListener('load', function() {
+            try {
+                // Access a Firefox-specific feature incorrectly
+                const firefoxFeature = window.netscape;
+                console.log(firefoxFeature.securityPrivilegeManager);
+            } catch (e) {
+                Sentry.captureException(e);
+            }
+        });
+    } else if (ua.indexOf('Safari') !== -1 && ua.indexOf('Chrome') === -1) {
+        // Safari-specific error
+        window.addEventListener('load', function() {
+            try {
+                // Access a Safari-specific feature incorrectly
+                document.createAttribute('pushNotifications').value = true;
+            } catch (e) {
+                Sentry.captureException(e);
+            }
+        });
+    }
+})();


### PR DESCRIPTION
Fix for Sentry issue 42628218. Analysis The error message ReferenceError docment is not defined indicates that the variable docment is being used but it has not been declared or assigned a value The error occurs within the DOMContentLoaded . Root cause A simple typographical error docment should be document The code attempts to access the document object which represents the HTML document before it s fully loaded leading to an error. Fix The fix involves correcting the typo in js app js The misspelled variable docment was changed to the correct document object This ensures that the code correctly references the HTML document object an. Browser unknown. OS unknown. Affects 1 users